### PR TITLE
Add GET endpoints to TodoController and TodoService for retrieving todos

### DIFF
--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  ParseIntPipe,
+} from '@nestjs/common';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { Todo } from './entities/todo.entity';
@@ -10,5 +17,15 @@ export class TodoController {
   @Post()
   create(@Body() createTodoDto: CreateTodoDto): Todo {
     return this.todoService.create(createTodoDto);
+  }
+
+  @Get()
+  findAll(): Todo[] {
+    return this.todoService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number): Todo {
+    return this.todoService.findOne(id);
   }
 }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { Todo } from './entities/todo.entity';
 
@@ -10,6 +10,16 @@ export class TodoService {
   create(createTodoDto: CreateTodoDto): Todo {
     const todo = new Todo(this.idSeq++, createTodoDto.title);
     this.todos.push(todo);
+    return todo;
+  }
+
+  findAll(): Todo[] {
+    return this.todos;
+  }
+
+  findOne(id: number): Todo {
+    const todo = this.todos.find((todo) => todo.id === id);
+    if (!todo) throw new NotFoundException(`Todo with id: ${id} is not found`);
     return todo;
   }
 }


### PR DESCRIPTION
* Added `GET /todo` endpoint to return all todos in the `TodoController` and corresponding `findAll` method in the `TodoService`.
* Added `GET /todo/:id` endpoint to return a specific todo by ID, including input validation using `ParseIntPipe`, and implemented the corresponding `findOne` method in the service.
* Introduced `NotFoundException` in the `TodoService.findOne` method to throw a clear error if a todo with the specified ID does not exist.