### PR TITLE
Implement update title and status management for Todo items

### DIFF
--- a/src/todo/dto/update-title.dto.ts
+++ b/src/todo/dto/update-title.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateTitleDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+}

--- a/src/todo/dto/update-title.dto.ts
+++ b/src/todo/dto/update-title.dto.ts
@@ -1,6 +1,10 @@
+import { Transform } from 'class-transformer';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class UpdateTitleDto {
+  @Transform(
+    ({ value }) => (typeof value === 'string' ? value.trim() : value) as string,
+  )
   @IsString()
   @IsNotEmpty()
   title: string;

--- a/src/todo/entities/todo.entity.ts
+++ b/src/todo/entities/todo.entity.ts
@@ -6,5 +6,7 @@ export class Todo {
     public title: string,
     public createdAt: Date = new Date(),
     public status: Status = Status.PENDING,
+    public inProgressAt?: Date, // set when status changes to IN_PROGRESS
+    public completedAt?: Date, // set when status changes to COMPLETED
   ) {}
 }

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -5,10 +5,12 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
 } from '@nestjs/common';
 import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { Todo } from './entities/todo.entity';
+import { UpdateTitleDto } from './dto/update-title.dto';
 
 @Controller('todo')
 export class TodoController {
@@ -27,5 +29,23 @@ export class TodoController {
   @Get(':id')
   findOne(@Param('id', ParseIntPipe) id: number): Todo {
     return this.todoService.findOne(id);
+  }
+
+  @Patch(':id/title')
+  updateTitle(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateTitleDto,
+  ): Todo {
+    return this.todoService.updateTitle(id, dto.title);
+  }
+
+  @Patch(':id/in-progress')
+  markInProgress(@Param('id', ParseIntPipe) id: number): Todo {
+    return this.todoService.markInProgress(id);
+  }
+
+  @Patch(':id/completed')
+  markCompleted(@Param('id', ParseIntPipe) id: number): Todo {
+    return this.todoService.markCompleted(id);
   }
 }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -1,6 +1,11 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { Todo } from './entities/todo.entity';
+import { Status } from './enums/todo-status.enum';
 
 @Injectable()
 export class TodoService {
@@ -20,6 +25,36 @@ export class TodoService {
   findOne(id: number): Todo {
     const todo = this.todos.find((todo) => todo.id === id);
     if (!todo) throw new NotFoundException(`Todo with id: ${id} is not found`);
+    return todo;
+  }
+
+  updateTitle(id: number, title: string): Todo {
+    const todo = this.findOne(id);
+    if (!title.trim()) throw new BadRequestException('Title cannot be empty');
+    todo.title = title.trim();
+    return todo;
+  }
+
+  markInProgress(id: number): Todo {
+    const todo = this.findOne(id);
+    if (todo.status === Status.COMPLETED) {
+      throw new BadRequestException(
+        'Cannot move from Completed to in progress status',
+      );
+    }
+    if (todo.status !== Status.IN_PROGRESS) {
+      todo.status = Status.IN_PROGRESS;
+      todo.inProgressAt = new Date();
+    }
+    return todo;
+  }
+
+  markCompleted(id: number): Todo {
+    const todo = this.findOne(id);
+    if (todo.status !== Status.COMPLETED) {
+      todo.status = Status.COMPLETED;
+      todo.completedAt = new Date();
+    }
     return todo;
   }
 }

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -30,18 +30,12 @@ export class TodoService {
 
   updateTitle(id: number, title: string): Todo {
     const todo = this.findOne(id);
-    if (!title.trim()) throw new BadRequestException('Title cannot be empty');
-    todo.title = title.trim();
+    todo.title = title;
     return todo;
   }
 
   markInProgress(id: number): Todo {
     const todo = this.findOne(id);
-    if (todo.status === Status.COMPLETED) {
-      throw new BadRequestException(
-        'Cannot move from Completed to in progress status',
-      );
-    }
     if (todo.status !== Status.IN_PROGRESS) {
       todo.status = Status.IN_PROGRESS;
       todo.inProgressAt = new Date();


### PR DESCRIPTION
* Added three new PATCH endpoints to `TodoController` for updating a todo's title, marking a todo as in-progress, and marking a todo as completed. Each endpoint calls the corresponding service method.

* Introduced `UpdateTitleDto` with validation to ensure the title is a non-empty string.

* Extended the `Todo` entity with optional `inProgressAt` and `completedAt` fields to track when status changes occur.