### PR TITLE
Refactor TodoController and TodoService to update todo status; add Up…

### DIFF
--- a/src/todo/dto/update-status.dto.ts
+++ b/src/todo/dto/update-status.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty } from 'class-validator';
+import { Status } from '../enums/todo-status.enum';
+
+export class UpdateStatusDto {
+  @ApiProperty({
+    description: 'The new status for the todo item',
+    enum: Status,
+    example: Status.IN_PROGRESS,
+  })
+  @IsEnum(Status, { message: 'Status must be a valid status value' })
+  @IsNotEmpty()
+  status: Status;
+}

--- a/src/todo/todo.controller.ts
+++ b/src/todo/todo.controller.ts
@@ -20,6 +20,7 @@ import { TodoService } from './todo.service';
 import { CreateTodoDto } from './dto/create-todo.dto';
 import { Todo } from './entities/todo.entity';
 import { UpdateTitleDto } from './dto/update-title.dto';
+import { UpdateStatusDto } from './dto/update-status.dto';
 
 @ApiTags('todos')
 @Controller('todos')
@@ -93,40 +94,26 @@ export class TodoController {
     return this.todoService.updateTitle(id, dto.title);
   }
 
-  @Patch(':id/in-progress')
+  @Patch(':id/status')
   @ApiOperation({
-    summary: 'Mark todo as in progress',
-    description: 'Marks a specific todo item as in progress',
+    summary: 'Update todo status',
+    description: 'Updates the status of a specific todo item',
   })
   @ApiParam({
     name: 'id',
     description: 'The ID of the todo item',
     type: 'number',
   })
+  @ApiBody({ type: UpdateStatusDto })
   @ApiOkResponse({
-    description: 'The updated todo item marked as in progress',
+    description: 'The updated todo item',
     type: Todo,
   })
-  async markInProgress(@Param('id', ParseIntPipe) id: number): Promise<Todo> {
-    return this.todoService.markInProgress(id);
-  }
-
-  @Patch(':id/completed')
-  @ApiOperation({
-    summary: 'Mark todo as completed',
-    description: 'Marks a specific todo item as completed',
-  })
-  @ApiParam({
-    name: 'id',
-    description: 'The ID of the todo item',
-    type: 'number',
-  })
-  @ApiOkResponse({
-    description: 'The updated todo item marked as completed',
-    type: Todo,
-  })
-  async markCompleted(@Param('id', ParseIntPipe) id: number): Promise<Todo> {
-    return this.todoService.markCompleted(id);
+  async updateStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateStatusDto,
+  ): Promise<Todo> {
+    return this.todoService.updateStatus(id, dto.status);
   }
 
   @Delete(':id')

--- a/src/todo/todo.service.ts
+++ b/src/todo/todo.service.ts
@@ -43,26 +43,14 @@ export class TodoService {
     todo.title = title;
     return this.repo.save(todo);
   }
-
-  // MARK IN PROGRESS
-  async markInProgress(id: number): Promise<Todo> {
+  // UPDATE STATUS
+  async updateStatus(id: number, status: Status): Promise<Todo> {
     const todo = await this.mustFind(id);
-    if (todo.status !== Status.IN_PROGRESS) {
-      todo.status = Status.IN_PROGRESS;
-      if (!todo.inProgressAt) {
-        // makes sure you only set the timestamp once
+    if (todo.status !== status) {
+      todo.status = status;
+      if (status === Status.IN_PROGRESS && !todo.inProgressAt) {
         todo.inProgressAt = new Date();
-      }
-    }
-    return this.repo.save(todo);
-  }
-
-  // MARK COMPLETED
-  async markCompleted(id: number): Promise<Todo> {
-    const todo = await this.mustFind(id);
-    if (todo.status !== Status.COMPLETED) {
-      todo.status = Status.COMPLETED;
-      if (!todo.completedAt) {
+      } else if (status === Status.COMPLETED && !todo.completedAt) {
         todo.completedAt = new Date();
       }
     }


### PR DESCRIPTION
This pull request refactors how todo item statuses are updated by consolidating the separate "mark in progress" and "mark completed" endpoints into a single, more flexible status update endpoint. It introduces a new DTO for status updates and simplifies the service logic for updating statuses.

**API Endpoint Refactoring:**

* Replaced the separate `PATCH /:id/in-progress` and `PATCH /:id/completed` endpoints with a single `PATCH /:id/status` endpoint in `TodoController`, which accepts a new status via the request body.
* Updated the controller to use a new `UpdateStatusDto` for validating and documenting the status update payload.

**Service Logic Simplification:**

* Consolidated the `markInProgress` and `markCompleted` methods in `TodoService` into a single `updateStatus` method, which handles updating the status and the corresponding timestamp fields (`inProgressAt`, `completedAt`) as appropriate.

**DTO and Validation Improvements:**

* Added a new `UpdateStatusDto` class with validation and Swagger documentation for the status field, ensuring only valid status values can be submitted.